### PR TITLE
Bump to v2024.3.0

### DIFF
--- a/Casks/freifunk-meet.rb
+++ b/Casks/freifunk-meet.rb
@@ -1,6 +1,6 @@
 cask "freifunk-meet" do
-  version "2023.1.0"
-  sha256 "6232ecaa54f1788046f79f7aef9d0b5cb06b7203851c24e633e758fbdaa70982"
+  version "2024.3.0"
+  sha256 "7eb824e59bd72c1cb9c56e3ee0570e53ced8bdcdc7d15fa6dcc7d24ec0b3c754"
 
   url "https://github.com/freifunkMUC/jitsi-meet-electron/releases/download/v#{version}/ffmuc-meet.dmg"
   appcast "https://github.com/FreifunkMUC/jitsi-meet-electron/releases.atom"

--- a/get-latest-sha256.sh
+++ b/get-latest-sha256.sh
@@ -1,0 +1,2 @@
+wget https://github.com/freifunkMUC/jitsi-meet-electron/releases/latest/download/ffmuc-meet.dmg
+sha256sum ffmuc-meet.dmg

--- a/get-latest-sha256.sh
+++ b/get-latest-sha256.sh
@@ -1,2 +1,0 @@
-wget https://github.com/freifunkMUC/jitsi-meet-electron/releases/latest/download/ffmuc-meet.dmg
-sha256sum ffmuc-meet.dmg


### PR DESCRIPTION
- Update to latest meet client (v2024.3.0)
- add script to get sha256 code from latest release file